### PR TITLE
Units are named right, 

### DIFF
--- a/blitzkarte/utils/parsing/classes/country.ts
+++ b/blitzkarte/utils/parsing/classes/country.ts
@@ -26,7 +26,7 @@ export class Country {
     fleet: 0,
     garrison: 0,
     wing: 0,
-    nuke: undefined
+    nuke: 0
   };
   adjustments: number = 0;
   valid: boolean;

--- a/blitzkarte/utils/parsing/services/parse-orchestrator.ts
+++ b/blitzkarte/utils/parsing/services/parse-orchestrator.ts
@@ -392,13 +392,14 @@ export class Parser {
     this.units.forEach(unit => {
       let node: NodePin = this.referenceElement('nodes', unit.node);
       let province: Province = this.referenceElement('provinces', node.province);
+      const typeCased = unit.type.toLowerCase();
       province.unit.push(unit);
       if (province.country) {
         let country: Country = this.referenceElement('countries', province.country);
         if (country) {
           country.units.push(unit.name);
-          country.unitCounts[unit.type]++;
-          unit.fullName = `${unit.country} ${convertSnakeToTitleCase(unit.type)} ${country.unitCounts[unit.type]}`;
+          country.unitCounts[typeCased]++;
+          unit.fullName = `${unit.country} ${unit.type} ${country.unitCounts[typeCased]}`;
         } else {
           this.errors.push(`Unit ${province.name} country does not exist: ${province.country}`);
         }


### PR DESCRIPTION
Which somehow also keeps them from doubling up through the roof